### PR TITLE
Linting and rewrite of GMM subsetting

### DIFF
--- a/gmm/figures/common.py
+++ b/gmm/figures/common.py
@@ -9,30 +9,25 @@ import matplotlib
 import svgutils.transform as st
 from matplotlib import gridspec, pyplot as plt
 
-matplotlib.use('AGG')
+matplotlib.use("AGG")
 
-matplotlib.rcParams['legend.labelspacing'] = 0.2
-matplotlib.rcParams['legend.fontsize'] = 8
-matplotlib.rcParams['xtick.major.pad'] = 1.0
-matplotlib.rcParams['ytick.major.pad'] = 1.0
-matplotlib.rcParams['xtick.minor.pad'] = 0.9
-matplotlib.rcParams['ytick.minor.pad'] = 0.9
-matplotlib.rcParams['legend.handletextpad'] = 0.5
-matplotlib.rcParams['legend.handlelength'] = 0.5
-matplotlib.rcParams['legend.framealpha'] = 0.5
-matplotlib.rcParams['legend.markerscale'] = 0.7
-matplotlib.rcParams['legend.borderpad'] = 0.35
-matplotlib.rcParams['svg.fonttype'] = 'none'
+matplotlib.rcParams["legend.labelspacing"] = 0.2
+matplotlib.rcParams["legend.fontsize"] = 8
+matplotlib.rcParams["xtick.major.pad"] = 1.0
+matplotlib.rcParams["ytick.major.pad"] = 1.0
+matplotlib.rcParams["xtick.minor.pad"] = 0.9
+matplotlib.rcParams["ytick.minor.pad"] = 0.9
+matplotlib.rcParams["legend.handletextpad"] = 0.5
+matplotlib.rcParams["legend.handlelength"] = 0.5
+matplotlib.rcParams["legend.framealpha"] = 0.5
+matplotlib.rcParams["legend.markerscale"] = 0.7
+matplotlib.rcParams["legend.borderpad"] = 0.35
+matplotlib.rcParams["svg.fonttype"] = "none"
 
 
 def getSetup(figsize, gridd, multz=None, empts=None):
-    """ Establish figure set-up with subplots. """
-    sns.set(style="whitegrid",
-            font_scale=0.7,
-            color_codes=True,
-            palette="colorblind",
-            rc={'grid.linestyle': 'dotted',
-                'axes.linewidth': 0.6})
+    """Establish figure set-up with subplots."""
+    sns.set(style="whitegrid", font_scale=0.7, color_codes=True, palette="colorblind", rc={"grid.linestyle": "dotted", "axes.linewidth": 0.6})
 
     # create empty list if empts isn't specified
     if empts is None:
@@ -52,7 +47,7 @@ def getSetup(figsize, gridd, multz=None, empts=None):
         if x not in empts and x not in multz.keys():  # If this is just a normal subplot
             ax.append(f.add_subplot(gs1[x]))
         elif x in multz.keys():  # If this is a subplot that spans grid elements
-            ax.append(f.add_subplot(gs1[x: x + multz[x] + 1]))
+            ax.append(f.add_subplot(gs1[x : x + multz[x] + 1]))
             x += multz[x]
         x += 1
 
@@ -60,13 +55,13 @@ def getSetup(figsize, gridd, multz=None, empts=None):
 
 
 def subplotLabel(axs):
-    """ Place subplot labels on figure. """
+    """Place subplot labels on figure."""
     for ii, ax in enumerate(axs):
         ax.text(-0.2, 1.2, ascii_lowercase[ii], transform=ax.transAxes, fontweight="bold", va="top")
 
 
 def overlayCartoon(figFile, cartoonFile, x, y, scalee=1):
-    """ Add cartoon to a figure file. """
+    """Add cartoon to a figure file."""
 
     # Overlay Figure cartoons
     template = st.fromfile(figFile)
@@ -79,13 +74,13 @@ def overlayCartoon(figFile, cartoonFile, x, y, scalee=1):
 
 
 def genFigure():
-    """ Main figure generation function. """
-    fdir = './output/'
+    """Main figure generation function."""
+    fdir = "./output/"
     start = time.time()
-    nameOut = 'figure' + sys.argv[1]
+    nameOut = "figure" + sys.argv[1]
 
-    exec('from gmm.figures.' + nameOut + ' import makeFigure', globals())
+    exec("from gmm.figures." + nameOut + " import makeFigure", globals())
     ff = makeFigure()
-    ff.savefig(fdir + nameOut + '.svg', dpi=300, bbox_inches='tight', pad_inches=0)
+    ff.savefig(fdir + nameOut + ".svg", dpi=300, bbox_inches="tight", pad_inches=0)
 
-    print(f'Figure {sys.argv[1]} is done after {time.time() - start} seconds.\n')
+    print(f"Figure {sys.argv[1]} is done after {time.time() - start} seconds.\n")

--- a/gmm/figures/figure1.py
+++ b/gmm/figures/figure1.py
@@ -24,7 +24,7 @@ def makeFigure():
     subplotLabel(ax)
 
     # smallDF(Amount of cells wanted per experiment); 336 conditions in total
-    cellperexp = 1000
+    cellperexp = 200
     zflowDF, experimentalcells = smallDF(cellperexp)
 
     ax[0].hist(experimentalcells, bins=20)
@@ -41,7 +41,7 @@ def makeFigure():
     ax[1].set(xlabel=xlabel, ylabel=ylabel)
 
     # Determining rand_score for GMM with dataframe
-    scoreDF = cvGMM(zflowDF, 18)
+    scoreDF = cvGMM(zflowDF, 16)
 
     for i in range(len(components)):
         ax[2].plot(scoreDF.Cluster.values, scoreDF.rand_score.values)

--- a/gmm/figures/figure1.py
+++ b/gmm/figures/figure1.py
@@ -14,7 +14,7 @@ from ..GMM import cvGMM, runPCA, probGMM
 
 
 def makeFigure():
-    """ Get a list of the axis objects and create a figure. """
+    """Get a list of the axis objects and create a figure."""
     # Get list of axis objects
     ax, f = getSetup((8, 4), (2, 3))
 
@@ -24,14 +24,13 @@ def makeFigure():
     subplotLabel(ax)
 
     # smallDF(Amount of cells wanted per experiment); 336 conditions in total
-    cellperexp = 50
-    zflowDF, experimentalcells  = smallDF(cellperexp)
+    cellperexp = 1000
+    zflowDF, experimentalcells = smallDF(cellperexp)
 
     ax[0].hist(experimentalcells, bins=20)
     xlabel = "Number of Cells per Experiment"
-    ylabel = "Events" 
+    ylabel = "Events"
     ax[0].set(xlabel=xlabel, ylabel=ylabel)
-
 
     # # PCA(Runs PCA on dataframe with output [PCs,VarianceExplained])
     components, vcexplained = runPCA(zflowDF)
@@ -58,7 +57,5 @@ def makeFigure():
     print(nk)
     print(means)
     print(covariances)
-
-
 
     return f

--- a/gmm/figures/figure2.py
+++ b/gmm/figures/figure2.py
@@ -5,7 +5,7 @@ from .common import subplotLabel, getSetup
 
 
 def makeFigure():
-    """ Get a list of the axis objects and create a figure. """
+    """Get a list of the axis objects and create a figure."""
     # Get list of axis objects
     ax, f = getSetup((8, 4), (2, 3))
 

--- a/gmm/figures/figure3.py
+++ b/gmm/figures/figure3.py
@@ -5,7 +5,7 @@ from .common import subplotLabel, getSetup
 
 
 def makeFigure():
-    """ Get a list of the axis objects and create a figure. """
+    """Get a list of the axis objects and create a figure."""
     # Get list of axis objects
     ax, f = getSetup((8, 4), (2, 3))
 

--- a/gmm/tests/test_GMM.py
+++ b/gmm/tests/test_GMM.py
@@ -1,14 +1,21 @@
-'''
+"""
 Test the data import.
-'''
+"""
 import pytest
 import pandas as pd
 from ..imports import smallDF
-from ..GMM import cvGMM
+from ..GMM import cvGMM, probGMM
 
 
 def test_import():
-    """ Stub test. """
-    dataTwo = smallDF(50)
-    gmmDF = cvGMM(dataTwo, 5)
+    """Stub test."""
+    dataTwo, _ = smallDF(50)
+    gmmDF = cvGMM(dataTwo, 4)
     assert isinstance(gmmDF, pd.DataFrame)
+
+
+def test_GMMprob():
+    """Test that we can construct a covariance matrix including pSTAT5."""
+    cellperexp = 50
+    dataTwo, _ = smallDF(cellperexp)
+    gmmDF = probGMM(dataTwo, 4, cellperexp)

--- a/gmm/tests/test_import.py
+++ b/gmm/tests/test_import.py
@@ -1,12 +1,12 @@
-'''
+"""
 Test the data import.
-'''
+"""
 import pytest
 from ..imports import smallDF
 
 
 def test_import():
-    """ Stub test. """
-    data = smallDF(10)
-    dataTwo = smallDF(20)
+    """Stub test."""
+    data, _ = smallDF(10)
+    dataTwo, _ = smallDF(20)
     assert 2 * data.shape[0] == dataTwo.shape[0]


### PR DESCRIPTION
I rewrote parts of the new GMM method to fix a few issues. Firstly, you want to run the GMM on the entire dataset, and then extract the responsibilities matrix. From there the dataset can be subsetted by condition to get the means and covariances. I noticed that pSTAT5 wasn't being normalized on import so I fixed that. `probGMM` now returns a big array of the cluster sizes, means, and covariances.

Also take a look at how I've setup a docstring for the method and file. Getting in the habit of filling these out will make it easier to follow what each method accomplishes.

I also linted using the black formatter and autopep8.