### PR TITLE
Jaxify GMMs

### DIFF
--- a/gmm/figures/figure4.py
+++ b/gmm/figures/figure4.py
@@ -35,8 +35,12 @@ def makeFigure():
     nkValues = np.exp(np.nanmean(np.log(nk), axis=(1, 2, 3)))
     cpVector = cp_to_vector(facInfo)
 
-    optimized = minimize(maxloglik, cpVector, method="Nelder-Mead",
-                         args=(facInfo, tCovar, nkValues, zflowTensor), options={"disp": True, "maxiter": 10})
+    def callbk(xk):
+        print(maxloglik(xk, facInfo, tCovar, nkValues, zflowTensor))
+        return False
+
+    optimized = minimize(maxloglik, cpVector, callback=callbk,
+                         args=(facInfo, tCovar, nkValues, zflowTensor), options={"disp": True, "maxiter": 200})
 
     print("Optimized Parameters:", optimized)
 

--- a/gmm/tensor.py
+++ b/gmm/tensor.py
@@ -131,5 +131,5 @@ def maxloglik(facVector: np.ndarray, facInfo: tl.cp_tensor.CPTensor, tPrecision:
     factorsguess = vector_to_cp(facVector, facInfo.rank, facInfo.shape)
     rebuildMeans = tl.cp_to_tensor(factorsguess)
 
-    ll = comparingGMM(zflowTensor, rebuildMeans, tPrecision, nk)
+    ll = comparingGMMjax(zflowTensor, rebuildMeans, tPrecision.to_numpy(), nk)
     return -ll

--- a/gmm/tests/test_GMM.py
+++ b/gmm/tests/test_GMM.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_allclose
 from tensorly.random import random_cp
 from ..imports import smallDF
 from ..GMM import cvGMM, probGMM
-from ..tensor import cp_to_vector, vector_to_cp, comparingGMM
+from ..tensor import cp_to_vector, vector_to_cp, comparingGMM, comparingGMMjax
 
 data_import, other_import = smallDF(10)
 
@@ -33,7 +33,7 @@ def test_comparingGMM():
     nk, tMeans, tCovar = probGMM(data_import, 2)
     nkValues = np.exp(np.nanmean(np.log(nk), axis=(1, 2, 3)))
 
-    optimized1 = comparingGMM(data_import, tMeans, tCovar, nkValues)
-    optimized2 = comparingGMM(data_import, tMeans, tCovar, nkValues)
+    optimized1 = comparingGMM(data_import, tMeans, tCovar.to_numpy(), nkValues)
+    optimized2 = comparingGMMjax(data_import, tMeans, tCovar.to_numpy(), nkValues)
 
-    assert optimized1 == optimized2
+    np.testing.assert_almost_equal(optimized1, optimized2)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1026,7 +1026,6 @@ lxml = [
     {file = "lxml-4.8.0-cp35-cp35m-win_amd64.whl", hash = "sha256:530f278849031b0eb12f46cca0e5db01cfe5177ab13bd6878c6e739319bae654"},
     {file = "lxml-4.8.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:078306d19a33920004addeb5f4630781aaeabb6a8d01398045fcde085091a169"},
     {file = "lxml-4.8.0-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:86545e351e879d0b72b620db6a3b96346921fa87b3d366d6c074e5a9a0b8dadb"},
-    {file = "lxml-4.8.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:24f5c5ae618395ed871b3d8ebfcbb36e3f1091fd847bf54c4de623f9107942f3"},
     {file = "lxml-4.8.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:bbab6faf6568484707acc052f4dfc3802bdb0cafe079383fbaa23f1cdae9ecd4"},
     {file = "lxml-4.8.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7993232bd4044392c47779a3c7e8889fea6883be46281d45a81451acfd704d7e"},
     {file = "lxml-4.8.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6d6483b1229470e1d8835e52e0ff3c6973b9b97b24cd1c116dca90b57a2cc613"},


### PR DESCRIPTION
This converts the GMM likelihood calculation into a vectorized form. It's tested to give the same answer as using scikit-learn's GMM method. Some rough benchmarking shows this is about 250X faster. :-)