### PR TITLE
Unify the factors matrices

### DIFF
--- a/gmm/figures/figure4.py
+++ b/gmm/figures/figure4.py
@@ -9,7 +9,7 @@ from jax import value_and_grad
 from .common import subplotLabel, getSetup
 from gmm.imports import smallDF
 from gmm.GMM import probGMM
-from gmm.tensor import tensor_decomp, cp_to_vector, tensorcovar_decomp, pt_to_vector, maxloglik_ptnnp
+from gmm.tensor import tensor_decomp, tensorcovar_decomp, cp_pt_to_vector, maxloglik_ptnnp
 
 
 config.update("jax_enable_x64", True)
@@ -40,15 +40,13 @@ def makeFigure():
     ranknumb = 3
     _, facInfo = tensor_decomp(tMeans, ranknumb, "NNparafac")
 
-    ptFactors, ptCore = tensorcovar_decomp(tPrecision, ranknumb)
+    _, ptCore = tensorcovar_decomp(tPrecision, ranknumb)
 
-    vecptFacCore = pt_to_vector(ptFactors, ptCore)
-
+    facVector = cp_pt_to_vector(facInfo, ptCore)
     nkValues = np.exp(np.nanmean(np.log(nk), axis=(1, 2, 3)))
-    cpVector = cp_to_vector(facInfo)
-    totalVector = np.concatenate((nkValues, cpVector, vecptFacCore))
+    totalVector = np.concatenate((nkValues, facVector))
 
-    args = (tPrecision, facInfo, zflowTensor, len(cpVector), ptCore)
+    args = (facInfo, zflowTensor, ptCore)
 
     tl.set_backend("jax")
 

--- a/gmm/figures/figure4.py
+++ b/gmm/figures/figure4.py
@@ -46,7 +46,7 @@ def makeFigure():
     nkValues = np.exp(np.nanmean(np.log(nk), axis=(1, 2, 3)))
     totalVector = np.concatenate((nkValues, facVector))
 
-    args = (facInfo, zflowTensor, ptCore)
+    args = (facInfo, zflowTensor)
 
     tl.set_backend("jax")
 

--- a/gmm/tensor.py
+++ b/gmm/tensor.py
@@ -71,7 +71,7 @@ def cp_pt_to_vector(facinfo: tl.cp_tensor.CPTensor, ptCore):
     return vec
 
 
-def vector_to_cp_pt(vectorIn, rank: int, shape: tuple, ptCore: np.ndarray):
+def vector_to_cp_pt(vectorIn, rank: int, shape: tuple):
     """Converts linear vector to factors"""
     # Shape of tensor for means or precision matrix
     nN = jnp.cumsum(np.array(shape) * rank)
@@ -81,7 +81,7 @@ def vector_to_cp_pt(vectorIn, rank: int, shape: tuple, ptCore: np.ndarray):
     # Rebuidling factors and ranks
 
     factors_pt = [factors[0], factors[2], factors[3], factors[4]]
-    ptNewCore = vectorIn[nN[-1]::].reshape(*ptCore.shape)
+    ptNewCore = vectorIn[nN[-1]::].reshape(rank, shape[1], shape[1], rank, rank, rank)
 
     return tl.cp_tensor.CPTensor((None, factors)), factors_pt, ptNewCore
 
@@ -135,11 +135,11 @@ def comparingGMMjax(X, tMeans, tPrecision, nk):
     return loglik
 
 
-def maxloglik_ptnnp(facVector, facInfo: tl.cp_tensor.CPTensor, zflowTensor: xa.DataArray, ptCore):
+def maxloglik_ptnnp(facVector, facInfo: tl.cp_tensor.CPTensor, zflowTensor: xa.DataArray):
     """Function used to rebuild tMeans from factors and maximize log-likelihood"""
     rebuildnk = facVector[0 : facInfo.shape[0]]
 
-    factorsguess, rebuildPtFactors, rebuildPtCore = vector_to_cp_pt(facVector[facInfo.shape[0]::], facInfo.rank, facInfo.shape, ptCore)
+    factorsguess, rebuildPtFactors, rebuildPtCore = vector_to_cp_pt(facVector[facInfo.shape[0]::], facInfo.rank, facInfo.shape)
     rebuildMeans = tl.cp_to_tensor(factorsguess)
 
     rebuildPrecision = multi_mode_dot(rebuildPtCore, rebuildPtFactors, modes=[0, 3, 4, 5], transpose=False)

--- a/gmm/tensor.py
+++ b/gmm/tensor.py
@@ -59,21 +59,11 @@ def tensor_R2X(tensor: xa.DataArray, maxrank: int, tensortype):
     return rank, varexpl
 
 
-def cp_to_vector(facinfo: tl.cp_tensor.CPTensor):
+def cp_pt_to_vector(facinfo: tl.cp_tensor.CPTensor, ptCore):
     """Converts from factors to a linear vector."""
     vec = np.array([], dtype=float)
 
     for fac in facinfo.factors:
-        vec = np.append(vec, fac.flatten())
-
-    return vec
-
-
-def pt_to_vector(ptFactors, ptCore):
-    """Converts from factors to a linear vector."""
-    vec = np.array([], dtype=float)
-
-    for fac in ptFactors:
         vec = np.append(vec, fac.flatten())
 
     vec = np.append(vec, ptCore.flatten())
@@ -81,7 +71,7 @@ def pt_to_vector(ptFactors, ptCore):
     return vec
 
 
-def vector_to_cp(vectorIn, rank: int, shape: tuple):
+def vector_to_cp_pt(vectorIn, rank: int, shape: tuple, ptCore: np.ndarray):
     """Converts linear vector to factors"""
     # Shape of tensor for means or precision matrix
     nN = jnp.cumsum(np.array(shape) * rank)
@@ -89,20 +79,11 @@ def vector_to_cp(vectorIn, rank: int, shape: tuple):
 
     factors = [jnp.reshape(vectorIn[nN[ii] : nN[ii + 1]], (shape[ii], rank)) for ii in range(len(shape))]
     # Rebuidling factors and ranks
-    return tl.cp_tensor.CPTensor((None, factors))
 
+    factors_pt = [factors[0], factors[2], factors[3], factors[4]]
+    ptNewCore = vectorIn[nN[-1]::].reshape(*ptCore.shape)
 
-def vector_to_pt(ptVector, ranknumb: int, tPrecision, ptCore: np.ndarray):
-    """Converts linear vector into partial tucker core and factors"""
-    modesPrecision = np.array([tPrecision.shape[0], tPrecision.shape[3], tPrecision.shape[4], tPrecision.shape[5]])
-
-    nN = jnp.cumsum(modesPrecision) * ranknumb
-    nN = jnp.insert(nN, 0, 0)
-
-    factors = [jnp.reshape(ptVector[nN[ii] : nN[ii + 1]], (modesPrecision[ii], ranknumb)) for ii in range(len(modesPrecision))]
-    ptNewCore = ptVector[nN[-1]::].reshape(*ptCore.shape)
-
-    return factors, ptNewCore
+    return tl.cp_tensor.CPTensor((None, factors)), factors_pt, ptNewCore
 
 
 def comparingGMM(zflowDF: xa.DataArray, tMeans: np.ndarray, tPrecision: np.ndarray, nk: np.ndarray):
@@ -154,14 +135,13 @@ def comparingGMMjax(X, tMeans, tPrecision, nk):
     return loglik
 
 
-def maxloglik_ptnnp(facVector, tPrecision, facInfo: tl.cp_tensor.CPTensor, zflowTensor: xa.DataArray, cpVectorLength, ptCore):
+def maxloglik_ptnnp(facVector, facInfo: tl.cp_tensor.CPTensor, zflowTensor: xa.DataArray, ptCore):
     """Function used to rebuild tMeans from factors and maximize log-likelihood"""
     rebuildnk = facVector[0 : facInfo.shape[0]]
 
-    factorsguess = vector_to_cp(facVector[facInfo.shape[0] : facInfo.shape[0] + cpVectorLength], facInfo.rank, facInfo.shape)
+    factorsguess, rebuildPtFactors, rebuildPtCore = vector_to_cp_pt(facVector[facInfo.shape[0]::], facInfo.rank, facInfo.shape, ptCore)
     rebuildMeans = tl.cp_to_tensor(factorsguess)
 
-    rebuildPtFactors, rebuildPtCore = vector_to_pt(facVector[facInfo.shape[0] + cpVectorLength : :], facInfo.rank, tPrecision, ptCore)
     rebuildPrecision = multi_mode_dot(rebuildPtCore, rebuildPtFactors, modes=[0, 3, 4, 5], transpose=False)
     rebuildPrecision = jnp.abs(rebuildPrecision)  # TODO: Remove this eventually.
     rebuildPrecision = (rebuildPrecision + np.swapaxes(rebuildPrecision, 1, 2)) / 2.0  # Enforce symmetry

--- a/gmm/tests/test_GMM.py
+++ b/gmm/tests/test_GMM.py
@@ -4,10 +4,9 @@ Test the data import.
 import pandas as pd
 import numpy as np
 from numpy.testing import assert_allclose
-from tensorly.random import random_cp
 from ..imports import smallDF
 from ..GMM import cvGMM, probGMM
-from ..tensor import cp_to_vector, vector_to_cp, comparingGMM, comparingGMMjax
+from ..tensor import cp_pt_to_vector, vector_to_cp_pt, comparingGMM, comparingGMMjax
 
 data_import, other_import = smallDF(10)
 
@@ -20,12 +19,12 @@ def test_cvGMM():
 
 def test_CP_to_vec():
     """Test that we can go from Cp to vector, and from vector to Cp without changing values."""
-    cp_tensor = random_cp((10, 11, 12, 13, 14), 3, normalise_factors=False)
-    cpVector = cp_to_vector(cp_tensor)
-    vectorFac = vector_to_cp(cpVector, cp_tensor.rank, cp_tensor.shape)
+    rand_vec = np.random.random(2130)
 
-    for ii in range(len(vectorFac.factors)):
-        assert_allclose(vectorFac.factors[ii], cp_tensor.factors[ii])
+    built = vector_to_cp_pt(rand_vec, 3, (6, 5, 4, 12, 8))
+    out_vec = cp_pt_to_vector(built[0], built[2])
+
+    assert_allclose(rand_vec, out_vec)
 
 
 def test_comparingGMM():


### PR DESCRIPTION
This sets up the factor reconstructions to reuse the factors in the representation of the means and precisions tensors. It also reduces some of the redundant information passed around during fitting.