### PR TITLE
Rewrite multi_mode_dot of Tucker to have precision matrix patterns

### DIFF
--- a/gmm/figures/figure4.py
+++ b/gmm/figures/figure4.py
@@ -2,7 +2,6 @@
 This creates Figure 4.
 """
 import numpy as np
-import xarray as xa
 import seaborn as sns
 from jax.config import config
 from .common import subplotLabel, getSetup

--- a/gmm/figures/figure4.py
+++ b/gmm/figures/figure4.py
@@ -40,7 +40,7 @@ def makeFigure():
     _, tMeans, _ = probGMM(zflowTensor, maxcluster)
     _, facInfo = tensor_decomp(tMeans, ranknumb)
 
-    maximizedNK, maximizedFactors, ptNewCore = minimize_func(vectorGuess,facInfo,zflowTensor,tMeans)
+    maximizedNK, maximizedFactors, ptNewCore = minimize_func(vectorGuess, facInfo, zflowTensor, tMeans)
 
     ax[0].bar(np.arange(1, maxcluster + 1), maximizedNK)
     xlabel = "Cluster"

--- a/gmm/tensor.py
+++ b/gmm/tensor.py
@@ -66,9 +66,7 @@ def cp_pt_to_vector(facinfo: tl.cp_tensor.CPTensor, ptCore):
         vec = np.append(vec, fac.flatten())
         print(len(vec))
 
-
     vec = np.append(vec, ptCore.flatten())
-
 
     return vec
 
@@ -89,18 +87,22 @@ def vector_to_cp_pt(vectorIn, rank: int, shape: tuple):
 
 
 def vector_guess(zflowTensor, ranknumb, maxcluster):
-    factortotal = 0 
+    factortotal = 0
 
     for i, a in enumerate(zflowTensor.dims):
-        factortotal +=len(zflowTensor.coords[a])*ranknumb
+        factortotal += len(zflowTensor.coords[a]) * ranknumb
 
-    factortotal = factortotal - (len(zflowTensor.coords["Cell"])*ranknumb) + (ranknumb*maxcluster) + ((ranknumb**4)*(
-                len(markerslist)**2)) + maxcluster
+    factortotal = (
+        factortotal
+        - (len(zflowTensor.coords["Cell"]) * ranknumb)
+        + (ranknumb * maxcluster)
+        + ((ranknumb**4) * (len(markerslist) ** 2))
+        + maxcluster
+    )
 
     rand_vec = np.random.random(factortotal)
 
     return rand_vec
-
 
 
 def comparingGMM(zflowDF: xa.DataArray, tMeans: np.ndarray, tPrecision: np.ndarray, nk: np.ndarray):
@@ -165,8 +167,7 @@ def maxloglik_ptnnp(facVector, facInfo: tl.cp_tensor.CPTensor, zflowTensor: xa.D
     return -comparingGMMjax(zflowTensor.to_numpy(), rebuildMeans, rebuildPrecision, rebuildnk)
 
 
-
-def minimize_func(totalVector,facInfo,zflowTensor,tMeans):
+def minimize_func(totalVector, facInfo, zflowTensor, tMeans):
 
     args = (facInfo, zflowTensor)
 
@@ -189,6 +190,4 @@ def minimize_func(totalVector,facInfo,zflowTensor,tMeans):
     for ii, dd in enumerate(tMeans.dims):
         maximizedFactors.append(pd.DataFrame(maximizedCpInfo.factors[ii], columns=cmpCol, index=tMeans.coords[dd]))
 
-
-    return  maximizedNK, maximizedFactors, ptNewCore
-
+    return maximizedNK, maximizedFactors, ptNewCore

--- a/gmm/tensor.py
+++ b/gmm/tensor.py
@@ -85,7 +85,8 @@ def vector_to_cp_pt(vectorIn, rank: int, shape: tuple):
     return tl.cp_tensor.CPTensor((None, factors)), factors_pt, ptNewCore
 
 
-def vector_guess(zflowTensor, rank: int, n_cluster: int):
+def vector_guess(zflowTensor: xa.DataArray, rank: int, n_cluster: int):
+    """Predetermines total vector that will be maximized for NK, factors and core"""
     factortotal = np.sum(zflowTensor.shape) * rank
 
     factortotal = (
@@ -148,7 +149,7 @@ def comparingGMMjax(X, tMeans, tPrecision, nk):
     return loglik
 
 
-def maxloglik_ptnnp(facVector, shape, rank, zflowTensor: xa.DataArray):
+def maxloglik_ptnnp(facVector, shape, rank:int, zflowTensor: xa.DataArray):
     """Function used to rebuild tMeans from factors and maximize log-likelihood"""
     rebuildnk = facVector[0 : shape[0]]
 
@@ -162,6 +163,7 @@ def maxloglik_ptnnp(facVector, shape, rank, zflowTensor: xa.DataArray):
 
 
 def minimize_func(zflowTensor: xa.DataArray, rank: int, n_cluster: int):
+    """Function used to minimize loglikelihood to obtain NK, factors and core of Cp and Pt"""
     x0 = vector_guess(zflowTensor, rank, n_cluster)
 
     times = zflowTensor.coords["Time"]

--- a/gmm/tests/test_GMM.py
+++ b/gmm/tests/test_GMM.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from ..imports import smallDF
 from ..GMM import cvGMM, probGMM
-from ..tensor import cp_pt_to_vector, vector_to_cp_pt, comparingGMM, comparingGMMjax
+from ..tensor import cp_pt_to_vector, vector_to_cp_pt, comparingGMM, comparingGMMjax, vector_guess, maxloglik_ptnnp
 
 data_import, other_import = smallDF(10)
 
@@ -19,12 +19,17 @@ def test_cvGMM():
 
 def test_CP_to_vec():
     """Test that we can go from Cp to vector, and from vector to Cp without changing values."""
-    rand_vec = np.random.random(2130)
+    meanShape = (6, 5, 4, 12, 8)
+    x0 = vector_guess(meanShape, rank=3)
 
-    built = vector_to_cp_pt(rand_vec, 3, (6, 5, 4, 12, 8))
-    out_vec = cp_pt_to_vector(built[0], built[2])
+    built = vector_to_cp_pt(x0, 3, meanShape)
+    out_vec = cp_pt_to_vector(*built)
 
-    assert_allclose(rand_vec, out_vec)
+    # Check that we can get a likelihood
+    ll = maxloglik_ptnnp(x0, meanShape, 3, data_import)
+
+    assert np.isfinite(ll)
+    assert_allclose(x0, out_vec)
 
 
 def test_comparingGMM():


### PR DESCRIPTION
This PR:

- Reduces the size of the Tucker factorization by working with `rank` precision matrix patterns.
- Uses unbounded optimization through a variable transform.

This seems to get *much* better fits consistently, with the log-likelihood getting up to ~1E4 consistently (optimization therefore ~-1E4).