### PR TITLE
Properly handle SPD and optimize performance

### DIFF
--- a/gmm/tensor.py
+++ b/gmm/tensor.py
@@ -133,22 +133,24 @@ def comparingGMM(zflowDF: xa.DataArray, meanFact, tPrecision: np.ndarray, nk: np
     return loglik
 
 
-def comparingGMMjax(X, meanFact, tPrecision, nk):
+def comparingGMMjax(X, nk, meanFact, ptFact, ptCore):
     """Obtains the GMM means, convariances and NK values along with zflowDF mean marker values
     to determine the max log-likelihood"""
     assert nk.ndim == 1
     nkl = jnp.log(nk / jnp.sum(nk))
 
-    mp = jnp.einsum("iz,jz,kz,lz,mz,ijoklm->ioklm", *meanFact.factors, tPrecision)
-    Xp = jnp.einsum("jiklm,njoklm->inoklm", X, tPrecision)
+    mp = jnp.einsum("iz,jz,kz,lz,mz,ia,job,kc,ld,me,abcde->ioklm", *meanFact.factors, *ptFact, ptCore, optimize="greedy")
+    Xp = jnp.einsum("jiklm,na,job,kc,ld,me,abcde->inoklm", X, *ptFact, ptCore, optimize="greedy")
     log_prob = jnp.square(jnp.linalg.norm(Xp - mp[jnp.newaxis, :, :, :, :, :], axis=2))
     log_prob = -0.5 * (X.shape[0] * jnp.log(2 * jnp.pi) + log_prob)
 
     # The determinant of the precision matrix from the Cholesky decomposition
     # corresponds to the negative half of the determinant of the full precision matrix.
     # In short: det(precision_chol) = - det(precision) / 2
-    ppp = tPrecision.reshape(tPrecision.shape[0], -1, tPrecision.shape[3], tPrecision.shape[4], tPrecision.shape[5])
-    log_det = jnp.sum(jnp.log(ppp[:, :: X.shape[0] + 1, :, :, :]), 1)
+    unrav = jnp.reshape(ptFact[1], (-1, ptFact[1].shape[2]))
+    unrav = unrav[:: X.shape[0] + 1, :]
+    ppp = jnp.einsum("ab,ce,fg,hi,jk,begik->acfhj", ptFact[0], unrav, ptFact[2], ptFact[3], ptFact[4], ptCore, optimize="greedy")
+    log_det = jnp.sum(jnp.log(ppp), 1)
 
     # Since we are using the precision of the Cholesky decomposition,
     # `- 0.5 * log_det_precision` becomes `+ log_det_precision_chol`
@@ -158,13 +160,10 @@ def comparingGMMjax(X, meanFact, tPrecision, nk):
 
 def maxloglik_ptnnp(facVector, shape: tuple, rank: int, zflowTensor: xa.DataArray):
     """Function used to rebuild tMeans from factors and maximize log-likelihood"""
-    nk, meanFact, ptFact, ptCore = vector_to_cp_pt(facVector, rank, shape)
-
-    ptCoreFull = jnp.einsum("ijk,lkmno->lijmno", ptFact[1], ptCore)
-    ptBuilt = multi_mode_dot(ptCoreFull, [ptFact[0], ptFact[2], ptFact[3], ptFact[4]], modes=[0, 3, 4, 5], transpose=False)
+    parts = vector_to_cp_pt(facVector, rank, shape)
 
     # Creating function that we want to minimize
-    return -comparingGMMjax(zflowTensor.to_numpy(), meanFact, ptBuilt, nk)
+    return -comparingGMMjax(zflowTensor.to_numpy(), *parts)
 
 
 def minimize_func(zflowTensor: xa.DataArray, rank: int, n_cluster: int, maxiter=2000):

--- a/gmm/tests/test_GMM.py
+++ b/gmm/tests/test_GMM.py
@@ -23,7 +23,8 @@ def test_CP_to_vec():
     meanShape = (6, 5, 4, 12, 8)
     x0 = vector_guess(meanShape, rank=3)
 
-    built = vector_to_cp_pt(x0, 3, meanShape)
+    built = vector_to_cp_pt(x0, 3, meanShape, enforceSPD=False)
+    vector_to_cp_pt(x0, 3, meanShape, enforceSPD=True)
     out_vec = cp_pt_to_vector(*built)
 
     # Check that we can get a likelihood

--- a/gmm/tests/test_GMM.py
+++ b/gmm/tests/test_GMM.py
@@ -45,11 +45,11 @@ def test_comparingGMM():
     ptBuilt = (ptBuilt + np.swapaxes(ptBuilt, 1, 2)) / 2.0  # Enforce symmetry
 
     optimized1 = comparingGMM(data_import, meanFact, ptBuilt, nk)
-    optimized2 = comparingGMMjax(data_import.to_numpy(), meanFact, ptBuilt, nk)
+    optimized2 = comparingGMMjax(data_import.to_numpy(), nk, meanFact, ptFact, ptCore)
 
     np.testing.assert_almost_equal(optimized1, optimized2)
 
 
 def test_fit():
     """Test that fitting can run fine."""
-    nk, fac, core = minimize_func(data_import, 2, 3, maxiter=200)
+    nk, fac, core = minimize_func(data_import, 2, 3, maxiter=500)


### PR DESCRIPTION
- Use SVD to get the closest SPD precision matrix.
- Avoid full construction of the Precisions tensor.